### PR TITLE
Move VehicleRespawn scripts inside of the "tcs" folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Headless AI forced stances fixed, performance improvements, and new UGL/AT setting
 * Headless state machines updates.
 * Added support for the Discord Rich Presence mod
+* Moved the VehicleRespawn folder to fix the release build
 
 
 ### Fixed

--- a/CfgFunctions.hpp
+++ b/CfgFunctions.hpp
@@ -3,7 +3,6 @@
 class CfgFunctions{
 	#include "tcs\CfgFunctions.hpp"
 	#include "tcs\headless_ai\loadAI.sqf"
-	#include "VehicleRespawn\CfgFunctions.hpp"
 };
 
 #undef description_functions

--- a/VehicleRespawn/CfgFunctions.hpp
+++ b/VehicleRespawn/CfgFunctions.hpp
@@ -1,9 +1,0 @@
-class FRED_VehicleRespawn {
-	tag = "FRED";
-	class VehicleRespawn {
-		file = "VehicleRespawn";
-		class vehicleLoadout {};
-		class vehicleMonitor {};
-		class vehicleRespawn {};
-	};
-};

--- a/tcs/CfgFunctions.hpp
+++ b/tcs/CfgFunctions.hpp
@@ -208,4 +208,12 @@ class TCS {
     class initPlayerRichPresence {};
     class updatePlayerRPTicketCount {};
   };
+
+  class VehicleRespawn {
+		file = "tcs\vehicleRespawn";
+
+		class vehicleLoadout {};
+		class vehicleMonitor {};
+		class vehicleRespawn {};
+	};
 };

--- a/tcs/vehicleRespawn/fn_vehicleLoadout.sqf
+++ b/tcs/vehicleRespawn/fn_vehicleLoadout.sqf
@@ -15,7 +15,7 @@
 				- Array of items/magazines/weapons/backpacks.
 	
 	Example:
-		nul = [this, [[["Medikit","Toolkit"], [1, 2]],[],[],[]]] call FRED_fnc_vehicleLoadout
+		nul = [this, [[["Medikit","Toolkit"], [1, 2]],[],[],[]]] call TCS_fnc_vehicleLoadout
 */
 if (!isServer) exitWith {};
 private ["_itemArray", "_magazineArray", "_weaponArray", "_backpackArray"];

--- a/tcs/vehicleRespawn/fn_vehicleMonitor.sqf
+++ b/tcs/vehicleRespawn/fn_vehicleMonitor.sqf
@@ -51,7 +51,7 @@ while {true} do {
 				_newVehicle setPosASL _position;
 				_newVehicle setDir _direction;
 
-				if _loadout then {[_newVehicle, _inventory] call FRED_fnc_vehicleLoadout};
+				if _loadout then {[_newVehicle, _inventory] call TCS_fnc_vehicleLoadout};
 				if _savePaint then {[_newVehicle, _paint, _parts] call BIS_fnc_initVehicle};
 				
 				if _limitEnabled then {

--- a/tcs/vehicleRespawn/fn_vehicleRespawn.sqf
+++ b/tcs/vehicleRespawn/fn_vehicleRespawn.sqf
@@ -31,7 +31,7 @@
 					(Default: true)
 	
 	Example:
-		[this, 5, {_this allowDamage false;}, false] call FRED_fnc_vehicleRespawn;
+		[this, 5, {_this allowDamage false;}] call TCS_fnc_vehicleRespawn;
 */
 if (!isServer) exitWith {};
 private ["_inventory", "_paint", "_parts", "_vehicleData"];
@@ -76,7 +76,7 @@ _vehicleData = [
 
 if (isNil "VRMonitor") then {
 	TotalVRArray = [];
-	[] spawn FRED_fnc_vehicleMonitor;
+	[] spawn TCS_fnc_vehicleMonitor;
 	VRMonitor = 1;
 };
 


### PR DESCRIPTION
The VehicleRespawn scripts were not added to the tcs folder previously, so they weren't included in the Release. This change prevents users from needing to download the source code to get the complete TCS Framework.

**NOTE:** _This changes the function prefixes from FRED to TCS, so mission makers need to alter their scripts_